### PR TITLE
Add support for password reset

### DIFF
--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -37,5 +37,11 @@ urlpatterns = [
     path('register/', user_views.RegisterView.as_view()),
     path('profile/', user_views.ProfileView.as_view()),
     path('change_password/', user_views.ChangePasswordView.as_view()),
+    path('password_reset/',
+         user_views.PasswordResetView.as_view(),
+         name="password_reset"),
+    path('password_reset_confirm/<uidb64>/<token>/',
+         user_views.PasswordResetConfirmView.as_view(),
+         name='password_reset_confirm'),
     path('', include(router.urls)),
 ]

--- a/api/user/serializers.py
+++ b/api/user/serializers.py
@@ -1,5 +1,11 @@
+from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
+from django.contrib.auth.tokens import default_token_generator
+from django.utils.encoding import force_text
+from django.utils.http import urlsafe_base64_decode as uid_decoder
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from favorites.serializers import FavoriteProposicaoSerializer, FavoriteDeputadoSerializer
 from updates.serializers import UpdateSubscriptionSerializer
@@ -26,6 +32,7 @@ class UserSerializer(serializers.ModelSerializer):
     favorite_proposicoes = FavoriteProposicaoSerializer(many=True, read_only=True)
     favorite_deputados = FavoriteDeputadoSerializer(many=True, read_only=True)
     subscriptions = UpdateSubscriptionSerializer(many=True, read_only=True)
+
     class Meta:
         model = User
         fields = [
@@ -44,3 +51,49 @@ class ChangePasswordSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ['password']
+
+
+class PasswordResetSerializer(serializers.Serializer):
+
+    email = serializers.EmailField()
+
+    def validate_email(self, value):
+        self.reset_form = PasswordResetForm(data=self.initial_data)
+        if not self.reset_form.is_valid():
+            raise serializers.ValidationError(self.reset_form.errors)
+        return value
+
+    def save(self):
+        request = self.context.get('request')
+        self.reset_form.save(
+            use_https=request.is_secure(),
+            from_email=getattr(settings, 'DEFAULT_FROM_EMAIL'),
+            request=request,
+        )
+
+
+class PasswordResetConfirmSerializer(serializers.Serializer):
+    new_password1 = serializers.CharField(max_length=128)
+    new_password2 = serializers.CharField(max_length=128)
+    uid = serializers.CharField()
+    token = serializers.CharField()
+
+    def validate(self, attrs):
+        self._errors = {}
+
+        try:
+            uid = force_text(uid_decoder(attrs['uid']))
+            self.user = User._default_manager.get(pk=uid)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+            raise ValidationError({'uid': ['Valor invalido']})
+
+        self.set_password_form = SetPasswordForm(user=self.user, data=attrs)
+        if not self.set_password_form.is_valid():
+            raise serializers.ValidationError(self.set_password_form.errors)
+        if not default_token_generator.check_token(self.user, attrs['token']):
+            raise ValidationError({'token': ['Valor invalido']})
+
+        return attrs
+
+    def save(self):
+        return self.set_password_form.save()

--- a/api/user/views.py
+++ b/api/user/views.py
@@ -1,8 +1,14 @@
 from django.contrib.auth import get_user_model
 from rest_framework import views, status, authentication, permissions
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-from user.serializers import UserSerializer, NewUserSerializer, ChangePasswordSerializer
+
 from api.permissions import IsOwner
+from user.serializers import (UserSerializer, NewUserSerializer,
+                              ChangePasswordSerializer,
+                              PasswordResetSerializer,
+                              PasswordResetConfirmSerializer)
+
 
 User = get_user_model()
 
@@ -37,6 +43,40 @@ class ChangePasswordView(views.APIView):
             return Response({'status': 'OK'})
         return Response(serializer.errors,
                         status=status.HTTP_400_BAD_REQUEST)
+
+
+class PasswordResetView(views.APIView):
+    """
+        API endpoint that allows users to request a password reset.
+    """
+    serializer_class = PasswordResetSerializer
+    permission_classes = (AllowAny,)
+
+    def post(self, request, *args, **kwargs):
+        serializer = PasswordResetSerializer(data=request.data,
+                                             context={'request': request})
+        serializer.is_valid(raise_exception=True)
+
+        serializer.save()
+        return Response({"detail": "Password reset e-mail has been sent."},
+                        status=status.HTTP_200_OK)
+
+
+class PasswordResetConfirmView(views.APIView):
+    """
+        API endpoint that allows users with a valid token to reset their
+        passwords.
+    """
+    serializer_class = PasswordResetConfirmSerializer
+    permission_classes = (AllowAny,)
+
+    def post(self, request, *args, **kwargs):
+        serializer = PasswordResetConfirmSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(
+            {"detail": 'Password has been reset with the new password.'}
+        )
 
 
 class ProfileView(views.APIView):


### PR DESCRIPTION
This PR adds routes for a user password reset. and resolves #6 
Two new routes were created:
- "/reset_password"
- "/reset_password_confirm"

These routes use the user password forms from `django.contrib.auth` module.